### PR TITLE
ci: add goreleaser release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    name: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,50 @@
+version: 2
+
+project_name: praetorian
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - main: .
+    binary: praetorian
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/vdemeester/praetorian/version.Version={{ .Version }}
+      - -X github.com/vdemeester/praetorian/version.Commit={{ .ShortCommit }}
+      - -X github.com/vdemeester/praetorian/version.Date={{ .Date }}
+
+archives:
+  - formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    files:
+      - README.md
+      - LICENSE
+      - examples/**/*
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"
+
+release:
+  prerelease: auto

--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,12 @@ tidy:
 
 .PHONY: clean
 clean:
-	rm -rf $(BIN_DIR) coverage.out
+	rm -rf $(BIN_DIR) coverage.out dist
+
+.PHONY: snapshot
+snapshot:
+	goreleaser release --snapshot --clean
+
+.PHONY: release-check
+release-check:
+	goreleaser check

--- a/README.md
+++ b/README.md
@@ -102,7 +102,22 @@ make build    # build the binary into ./bin
 make test     # run unit tests
 make lint     # golangci-lint
 make check    # fmt + vet + lint + test
+make snapshot # build a local goreleaser snapshot (no publish)
 ```
+
+## Releasing
+
+Releases are cut by [goreleaser](https://goreleaser.com) when a `v*` tag is
+pushed:
+
+```sh
+git tag -a v2.0.0 -m "praetorian 2.0.0"
+git push origin v2.0.0
+```
+
+The `release` workflow builds static `linux`/`darwin` `amd64`/`arm64` binaries,
+produces checksums, and publishes a GitHub release. Validate config locally
+with `make release-check`.
 
 ## License
 


### PR DESCRIPTION
Adds release automation via [goreleaser](https://goreleaser.com).

- **`.goreleaser.yaml`** — static (`CGO_ENABLED=0`, `-trimpath`) builds for `linux`/`darwin` × `amd64`/`arm64`, version/commit/date ldflags into `version`, `tar.gz` archives (with README/LICENSE/examples), `checksums.txt`, filtered changelog.
- **`.github/workflows/release.yaml`** — runs `goreleaser release --clean` on `v*` tag push (uses the default `GITHUB_TOKEN`).
- **Makefile** — `make snapshot` (local build, no publish) and `make release-check` (validate config).
- **README** — Releasing section.

Cutting a release is just: `git tag -a vX.Y.Z -m ... && git push origin vX.Y.Z`.

Not triggered here — only validated by CI build/lint/test; the release job runs on tags.