### PR TITLE
chore: apply codecov tuning dropped in #19

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,17 +1,22 @@
 coverage:
+  precision: 2
+  round: down
   status:
     project:
       default:
-        target: auto
-        threshold: 1%
+        informational: true # report coverage, never block the PR
     patch:
       default:
-        target: 80%
+        target: 80% # the gate: new/changed code must be covered (TDD)
         threshold: 5%
+
+github_checks:
+  annotations: true
 
 comment:
   layout: "reach, diff, files"
   require_changes: true
 
 ignore:
+  - "main.go"
   - "version/**"


### PR DESCRIPTION
Follow-up to #19. That PR relocated `codecov.yml` → `.github/codecov.yml` but the content tuning was accidentally dropped (the file kept the old `project: target auto` settings). This applies the intended config:

- `project` status → **informational** (report, never block)
- `patch` gate stays **80%** (TDD)
- `precision: 2` / `round: down`
- `github_checks.annotations: true`
- ignore `main.go`