### PR TITLE
feat(nix): flake packaging (package + NixOS/home-manager modules)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,8 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26"
           cache: true
@@ -25,13 +25,13 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26"
           cache: true
       - run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           files: ./coverage.out
           fail_ci_if_error: false
@@ -42,12 +42,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26"
           cache: true
-      - uses: golangci/golangci-lint-action@v8
+      - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: latest
 
@@ -55,7 +55,7 @@ jobs:
     name: nix
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
       - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
       - run: nix flake check --print-build-logs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,3 +50,13 @@ jobs:
       - uses: golangci/golangci-lint-action@v8
         with:
           version: latest
+
+  nix:
+    name: nix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
+      - run: nix flake check --print-build-logs
+      - run: nix build --print-build-logs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,14 +13,14 @@ jobs:
     name: goreleaser
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.26"
           cache: true
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: latest
           args: release --clean

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage.out
 bundles
 /bin/
 /dist/
+result

--- a/README.md
+++ b/README.md
@@ -62,8 +62,11 @@ alias "okinawa-tpm" {
 Config lookup order (first found wins, **no merge**):
 
 1. `--config PATH`
-2. `~/.config/praetorian/config.hcl`
-3. `/etc/praetorian/config.hcl`
+2. `~/.config/praetorian/config.hcl`, then `config.json`
+3. `/etc/praetorian/config.hcl`, then `config.json`
+
+At each location the human-written HCL is preferred over a Nix-generated JSON
+config in the same directory.
 
 #### Constraints
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,65 @@
+{
+  description = "praetorian — SSH command restrictor (authorized_keys command= gate)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (pkgs: rec {
+        praetorian = pkgs.callPackage ./nix/package.nix { };
+        default = praetorian;
+      });
+
+      apps = forAllSystems (pkgs: rec {
+        praetorian = {
+          type = "app";
+          program = "${self.packages.${pkgs.stdenv.hostPlatform.system}.praetorian}/bin/praetorian";
+        };
+        default = praetorian;
+      });
+
+      overlays.default = _final: prev: {
+        praetorian = prev.callPackage ./nix/package.nix { };
+      };
+
+      nixosModules.praetorian = import ./nix/nixos-module.nix self;
+      nixosModules.default = self.nixosModules.praetorian;
+
+      homeManagerModules.praetorian = import ./nix/hm-module.nix self;
+      homeManagerModules.default = self.homeManagerModules.praetorian;
+
+      checks = forAllSystems (pkgs: {
+        # Build the package (compiles everything).
+        package = self.packages.${pkgs.stdenv.hostPlatform.system}.praetorian;
+
+        # Run the Go test suite as a flake check.
+        gotest = self.packages.${pkgs.stdenv.hostPlatform.system}.praetorian.overrideAttrs (_: {
+          doCheck = true;
+        });
+      });
+
+      formatter = forAllSystems (pkgs: pkgs.nixfmt-rfc-style);
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = [
+            pkgs.go
+            pkgs.golangci-lint
+            pkgs.goreleaser
+          ];
+        };
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -40,15 +40,25 @@
       homeManagerModules.praetorian = import ./nix/hm-module.nix self;
       homeManagerModules.default = self.homeManagerModules.praetorian;
 
-      checks = forAllSystems (pkgs: {
-        # Build the package (compiles everything).
-        package = self.packages.${pkgs.stdenv.hostPlatform.system}.praetorian;
+      checks = forAllSystems (
+        pkgs:
+        let
+          system = pkgs.stdenv.hostPlatform.system;
+        in
+        {
+          # Build the package (compiles everything).
+          package = self.packages.${system}.praetorian;
 
-        # Run the Go test suite as a flake check.
-        gotest = self.packages.${pkgs.stdenv.hostPlatform.system}.praetorian.overrideAttrs (_: {
-          doCheck = true;
-        });
-      });
+          # Run the Go test suite as a flake check.
+          gotest = self.packages.${system}.praetorian.overrideAttrs (_: {
+            doCheck = true;
+          });
+        }
+        # End-to-end SSH test via the NixOS VM test framework (Linux only).
+        // nixpkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+          e2e-ssh = import ./nix/tests/e2e-ssh.nix { inherit self pkgs; };
+        }
+      );
 
       formatter = forAllSystems (pkgs: pkgs.nixfmt-rfc-style);
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -42,22 +42,32 @@ Usage:
 
 Config lookup order (first found wins, no merge):
   1. --config PATH
-  2. ~/.config/praetorian/config.hcl
-  3. /etc/praetorian/config.hcl
+  2. ~/.config/praetorian/config.hcl, then config.json
+  3. /etc/praetorian/config.hcl, then config.json
 `)
 }
 
 // resolveConfigPath implements the documented lookup order. An explicit path
 // always wins (and is returned even if missing, so the error is clear).
+//
+// At each location HCL (human-written) is preferred over JSON (Nix-generated),
+// so a hand-edited config wins over a generated one in the same directory.
 func resolveConfigPath(explicit string) (string, error) {
 	if explicit != "" {
 		return explicit, nil
 	}
 	candidates := []string{}
 	if home, err := os.UserHomeDir(); err == nil {
-		candidates = append(candidates, filepath.Join(home, ".config", "praetorian", "config.hcl"))
+		dir := filepath.Join(home, ".config", "praetorian")
+		candidates = append(candidates,
+			filepath.Join(dir, "config.hcl"),
+			filepath.Join(dir, "config.json"),
+		)
 	}
-	candidates = append(candidates, "/etc/praetorian/config.hcl")
+	candidates = append(candidates,
+		"/etc/praetorian/config.hcl",
+		"/etc/praetorian/config.json",
+	)
 	for _, c := range candidates {
 		if _, err := os.Stat(c); err == nil {
 			return c, nil

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// resolveConfigPath should discover a JSON config (Nix-generated) in addition to
+// the human-written HCL config, at both the XDG and /etc locations.
+func TestResolveConfigPath_JSONFallback(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfgDir := filepath.Join(dir, ".config", "praetorian")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	jsonPath := filepath.Join(cfgDir, "config.json")
+	if err := os.WriteFile(jsonPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveConfigPath("")
+	if err != nil {
+		t.Fatalf("resolveConfigPath: %v", err)
+	}
+	if got != jsonPath {
+		t.Errorf("expected JSON config %q, got %q", jsonPath, got)
+	}
+}
+
+// When both config.hcl and config.json exist in the same directory, the
+// human-written HCL takes precedence.
+func TestResolveConfigPath_HCLBeatsJSON(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfgDir := filepath.Join(dir, ".config", "praetorian")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	hclPath := filepath.Join(cfgDir, "config.hcl")
+	jsonPath := filepath.Join(cfgDir, "config.json")
+	for _, p := range []string{hclPath, jsonPath} {
+		if err := os.WriteFile(p, []byte("{}"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := resolveConfigPath("")
+	if err != nil {
+		t.Fatalf("resolveConfigPath: %v", err)
+	}
+	if got != hclPath {
+		t.Errorf("expected HCL to win (%q), got %q", hclPath, got)
+	}
+}
+
+// An explicit path always wins, even if missing.
+func TestResolveConfigPath_ExplicitWins(t *testing.T) {
+	got, err := resolveConfigPath("/nonexistent/path.hcl")
+	if err != nil {
+		t.Fatalf("resolveConfigPath: %v", err)
+	}
+	if got != "/nonexistent/path.hcl" {
+		t.Errorf("expected explicit path, got %q", got)
+	}
+}

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,51 @@
+# home-manager module for praetorian (user-level install + config).
+#
+# Used on non-NixOS hosts (e.g. Fedora via standalone home-manager) or to place
+# config at ~/.config/praetorian/, praetorian's second config search location.
+self:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.praetorian;
+  format = pkgs.formats.json { };
+in
+{
+  options.services.praetorian = {
+    enable = lib.mkEnableOption "praetorian SSH command restrictor (user)";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.praetorian;
+      defaultText = lib.literalExpression "praetorian.packages.\${system}.praetorian";
+      description = "The praetorian package to use.";
+    };
+
+    aliases = lib.mkOption {
+      type = lib.types.attrsOf format.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          aomi-git.allow = {
+            "git-receive-pack" = { arg = { pos = 1; glob = "/home/vincent/git/*"; }; num_args = 1; };
+            "git-upload-pack"  = { arg = { pos = 1; glob = "/home/vincent/git/*"; }; num_args = 1; };
+          };
+        }
+      '';
+      description = ''
+        Alias -> allow-rule map rendered into ~/.config/praetorian/config.json.
+        Each alias maps `command="praetorian run <alias>"` to its allow rules.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+    xdg.configFile."praetorian/config.json".source = format.generate "praetorian-config.json" {
+      alias = cfg.aliases;
+    };
+  };
+}

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -1,0 +1,60 @@
+# NixOS module for praetorian.
+#
+# Installs the praetorian binary and renders /etc/praetorian/config.json from a
+# structured Nix attribute set. praetorian parses JSON natively (hclsimple
+# dispatches on the .json extension), so the Nix attrset below *is* the config:
+# its shape mirrors the HCL labeled-block schema exactly.
+#
+#   alias.<name>.allow.<command> = { arg = {pos; glob;}; num_args = N; any_arg; no_arg; };
+#
+# This module only handles installation + config generation. Wiring the
+# `command="praetorian run <alias>"` restriction into a user's authorized_keys
+# is the consumer's responsibility.
+self:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.praetorian;
+  format = pkgs.formats.json { };
+in
+{
+  options.services.praetorian = {
+    enable = lib.mkEnableOption "praetorian SSH command restrictor";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.praetorian;
+      defaultText = lib.literalExpression "praetorian.packages.\${system}.praetorian";
+      description = "The praetorian package to use.";
+    };
+
+    aliases = lib.mkOption {
+      type = lib.types.attrsOf format.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          aomi-git.allow = {
+            "git-receive-pack" = { arg = { pos = 1; glob = "/home/vincent/git/*"; }; num_args = 1; };
+            "git-upload-pack"  = { arg = { pos = 1; glob = "/home/vincent/git/*"; }; num_args = 1; };
+          };
+        }
+      '';
+      description = ''
+        Alias -> allow-rule map rendered into /etc/praetorian/config.json.
+        Each alias maps `command="praetorian run <alias>"` to its allow rules.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    environment.etc."praetorian/config.json".source = format.generate "praetorian-config.json" {
+      alias = cfg.aliases;
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildGoModule,
+}:
+let
+  fs = lib.fileset;
+in
+buildGoModule (finalAttrs: {
+  pname = "praetorian";
+  version = "2.0.0-dev";
+
+  # Only the files that affect the build — keeps the store path stable when docs
+  # or CI config change.
+  src = fs.toSource {
+    root = ../.;
+    fileset = fs.unions [
+      ../go.mod
+      ../go.sum
+      ../main.go
+      ../internal
+      ../version
+    ];
+  };
+
+  vendorHash = "sha256-V+Bz7oS9KHtI2w7Zes9ndZhVXquGEKxVIcGmd+Up2lY=";
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/vdemeester/praetorian/version.Version=${finalAttrs.version}"
+    "-X github.com/vdemeester/praetorian/version.Commit=nix"
+    "-X github.com/vdemeester/praetorian/version.Date=1970-01-01T00:00:00Z"
+  ];
+
+  meta = {
+    description = "SSH command restrictor (authorized_keys command= gate)";
+    homepage = "https://github.com/vdemeester/praetorian";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "praetorian";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/nix/tests/e2e-ssh.nix
+++ b/nix/tests/e2e-ssh.nix
@@ -1,0 +1,108 @@
+# End-to-end SSH test for praetorian (issue #24, OpenSSH path).
+#
+# Uses the NixOS test framework: a `server` node runs sshd + the praetorian
+# NixOS module; a `client` node generates an ephemeral keypair at runtime, the
+# server authorizes its public key with a forced command="praetorian run ci"
+# restriction, and the client drives real git operations plus adversarial
+# commands, asserting allowed-vs-denied. This also integration-tests the NixOS
+# module and config.json auto-discovery (the command= passes no --config).
+#
+# No private key is committed: the keypair is created inside the test VM.
+{ self, pkgs }:
+pkgs.testers.runNixOSTest {
+  name = "praetorian-e2e-ssh";
+
+  nodes.server =
+    { pkgs, ... }:
+    {
+      imports = [ self.nixosModules.praetorian ];
+
+      services.openssh.enable = true;
+      environment.systemPackages = [ pkgs.git ];
+
+      services.praetorian = {
+        enable = true;
+        aliases.ci.allow = {
+          "git-receive-pack".arg = {
+            pos = 1;
+            glob = "/srv/git/*";
+          };
+          "git-upload-pack".arg = {
+            pos = 1;
+            glob = "/srv/git/*";
+          };
+        };
+      };
+
+      # The git user's key is authorized at runtime (ephemeral key), so no key
+      # material lives in the Nix store. sshd reads ~/.ssh/authorized_keys.
+      users.users.git = {
+        isNormalUser = true;
+        home = "/home/git";
+      };
+
+      # Bare-repo parent directory, owned by the git user.
+      systemd.tmpfiles.rules = [ "d /srv/git 0755 git users -" ];
+    };
+
+  nodes.client =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = [
+        pkgs.git
+        pkgs.openssh
+      ];
+    };
+
+  testScript = ''
+    start_all()
+    server.wait_for_unit("sshd.service")
+
+    # Initialise a bare repo as the git user.
+    server.succeed("runuser -u git -- git init --bare /srv/git/test.git")
+
+    # Generate an ephemeral client keypair inside the VM (nothing committed).
+    client.succeed("mkdir -p /root/.ssh")
+    client.succeed("ssh-keygen -t ed25519 -N ''' -f /root/.ssh/id_ed25519")
+    pubkey = client.succeed("cat /root/.ssh/id_ed25519.pub").strip()
+
+    # Authorize it on the server with the forced praetorian command.
+    opts = "no-pty,no-agent-forwarding,no-port-forwarding,no-X11-forwarding"
+    server.succeed("install -d -m700 -o git -g users /home/git/.ssh")
+    server.succeed(
+        f"printf 'command=\"praetorian run ci\",{opts} %s\\n' '{pubkey}' "
+        "> /home/git/.ssh/authorized_keys"
+    )
+    server.succeed(
+        "chown git:users /home/git/.ssh/authorized_keys && "
+        "chmod 600 /home/git/.ssh/authorized_keys"
+    )
+
+    client.succeed("ssh-keyscan server > /root/.ssh/known_hosts 2>/dev/null")
+
+    ssh = "ssh -i /root/.ssh/id_ed25519 -o IdentitiesOnly=yes"
+    git_ssh = f"GIT_SSH_COMMAND='{ssh}'"
+
+    # ALLOWED: clone (git-upload-pack on /srv/git/*).
+    client.succeed(f"{git_ssh} git clone ssh://git@server/srv/git/test.git /tmp/clone")
+
+    # ALLOWED: push (git-receive-pack on /srv/git/*).
+    client.succeed(
+        "cd /tmp/clone && "
+        "git config user.email a@b.c && git config user.name t && "
+        "git commit --allow-empty -m e2e && "
+        f"{git_ssh} git push origin HEAD:master"
+    )
+
+    # DENIED: an arbitrary command is rejected by the gate.
+    client.fail(f"{ssh} git@server id")
+
+    # DENIED: a path outside the glob is rejected.
+    client.fail(f"{ssh} git@server git-upload-pack /etc/passwd")
+
+    # DENIED (no-shell invariant): shell metacharacters are inert bytes, not
+    # interpreted. "id; ls" tokenizes to ["id;", "ls"]; "id;" is not an allowed
+    # command, so it is denied rather than a shell running `id` then `ls`.
+    client.fail(f"{ssh} git@server 'id; ls'")
+  '';
+}


### PR DESCRIPTION
## Summary

Add Nix flake packaging and end-to-end SSH tests via the NixOS test framework (OpenSSH path). The flake exposes the praetorian package, an overlay, NixOS + home-manager modules, and `apps` outputs so consumers can pull the binary and modules from a single flake input and run directly via `nix run`.

Because praetorian parses JSON natively (hclsimple dispatches on the `.json` extension), the NixOS/home-manager modules render config via `pkgs.formats.json` — the Nix `aliases` attrset mirrors the HCL labeled-block schema and *is* the config. No HCL text generation needed.

## Changes

### Packaging
- `flake.nix`: `packages.<sys>.praetorian` (+ `default`), `apps.<sys>.praetorian` (+ `default` for `nix run`), `overlays.default`, `nixosModules.praetorian`, `homeManagerModules.praetorian`, `checks`, `devShell`, `formatter`.
- `nix/package.nix`: `buildGoModule`, static CGO-free build, fileset src, version stamping via ldflags.
- `nix/nixos-module.nix`: installs binary, renders `/etc/praetorian/config.json` from a structured `aliases` attrset. No `configFile` option — the module always writes to `/etc/praetorian/config.json`.
- `nix/hm-module.nix`: user-level install + `~/.config/praetorian/config.json` (non-NixOS hosts via standalone home-manager).
- `internal/cli`: discover `config.json` in the config search path (XDG and `/etc`), so the module-generated JSON is auto-discovered by `praetorian run` with no explicit `--config`. HCL is preferred over JSON in the same dir. Adds first CLI test coverage (`resolveConfigPath`).

### End-to-end tests
- `nix/tests/e2e-ssh.nix`: `pkgs.testers.runNixOSTest` with a `server` node (real `sshd` + the praetorian NixOS module gating a `git` user's key) and a `client` node driving real git over SSH. The keypair is generated *inside the test VM* at runtime (`ssh-keygen`) — no key material is committed to the repo. Asserts:
  - clone (`git-upload-pack`) and push (`git-receive-pack`) on `/srv/git/*` succeed;
  - an arbitrary command (`id`) is denied;
  - a path outside the glob (`git-upload-pack /etc/passwd`) is denied;
  - shell metacharacters are inert: `id; ls` tokenizes to `["id;", "ls"]`, `id;` is not allowed, proving `;` is never interpreted by a shell.
  - The `command=` passes **no** `--config`, so this also proves `config.json` auto-discovery end-to-end.
- Wired as `checks.<linux>.e2e-ssh` (Linux only — VM tests don't run on darwin).

### CI
- New `nix` job runs `nix flake check` (modules eval + Go suite + e2e VM test) and `nix build`, with `cachix/install-nix-action@v30` (pinned tag, no moving branch).

## Testing

- [x] `make check` passes (fmt + vet + lint + test)
- [x] New/changed behavior covered by tests (RED → GREEN): `resolveConfigPath` JSON fallback + HCL precedence + explicit-path; e2e allowed/denied paths + no-shell invariant.
- [x] `nix flake check` green (modules eval, Go suite via check).
- [x] `nix build .#praetorian` runs; version stamps correctly.
- [x] e2e NixOS VM test passes locally (KVM) with runtime-generated keypair.

## Checklist

- [x] No shell is introduced into the validate/exec path (commands stay
      tokenized + `syscall.Exec`)
- [x] Default-deny preserved; no new top-level deny rules
- [x] User-facing denials remain terse; details only in logs
- [x] No new dependencies (or justified above) — only Nix tooling, no Go deps
- [x] Docs/README updated if behavior or config changed (config lookup order)