### PR TITLE
ci: add dependabot for actions and go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: build
+    groups:
+      go:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Add `.github/dependabot.yml` enabling weekly Dependabot updates for **GitHub Actions** and **Go modules**.

## Why

CI actions are now SHA-pinned with version comments (see #26). SHA pins are immutable and protect against supply-chain tampering, but go stale silently. Dependabot understands the `uses: org/action@<sha> # vX.Y.Z` form and bumps **both** the SHA and the comment — keeping pinned dependencies current *without* losing the protection.

## Details

- `github-actions` ecosystem, weekly, grouped into a single PR (`ci:` prefix)
- `gomod` ecosystem, weekly, grouped into a single PR (`build:` prefix)
- Grouping avoids a flood of one-dependency PRs

> Note: Dependabot does not support Nix flake inputs; `flake.lock` updates remain manual (or a separate `update-flake-lock` action later).

> Repo-settings toggles (Dependabot security updates, secret scanning) are not file-based and still need enabling in **Settings → Code security**.